### PR TITLE
Create a separate folder for docker and make Dockerfile runnable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,13 +22,16 @@ VOLUME /opt/sling/sling
 
 # Setup Sling CMS
 RUN mkdir -p /opt/sling
-RUN wget https://repository.apache.org/content/repositories/snapshots/org/apache/sling/org.apache.sling.cms.builder/1.0.0-SNAPSHOT/org.apache.sling.cms.builder-1.0.0-20180512.031838-12.jar
+RUN wget -O org.apache.sling.cms.jar https://repository.apache.org/content/repositories/snapshots/org/apache/sling/org.apache.sling.cms.builder/0.11.3-SNAPSHOT/org.apache.sling.cms.builder-0.11.3-20181207.040617-10.jar
 ENV JAVA_OPTS -Xmx512m
 ENV SLING_OPTS ''
 
 # Install Apache
 RUN apt-get update 
 RUN apt-get install apache2 -y
+
+# Configure mod_rewrite
+RUN a2enmod rewrite
 
 # Configure mod_proxy
 RUN a2enmod proxy

--- a/docker/cache_disk.conf
+++ b/docker/cache_disk.conf
@@ -1,0 +1,16 @@
+#
+#		 Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#        agreements. See the NOTICE file distributed with this work for additional information
+#        regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+#        Version 2.0 (the "License"); you may not use this file except in compliance with the
+#        License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#        Unless required by applicable law or agreed to in writing, software distributed under the
+#        License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+#        either express or implied. See the License for the specific language governing permissions
+#        and limitations under the License.
+#
+
+<IfModule mod_cache_disk.c>
+    CacheDirLevels 2
+    CacheDirLength 1
+</IfModule>

--- a/docker/cms.conf
+++ b/docker/cms.conf
@@ -1,0 +1,22 @@
+#
+#		 Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#        agreements. See the NOTICE file distributed with this work for additional information
+#        regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+#        Version 2.0 (the "License"); you may not use this file except in compliance with the
+#        License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#        Unless required by applicable law or agreed to in writing, software distributed under the
+#        License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+#        either express or implied. See the License for the specific language governing permissions
+#        and limitations under the License.
+#
+
+<VirtualHost *:80>
+   ServerName cms.sling.apache.org
+   DocumentRoot /var/www/vhosts/sling-cms
+   ErrorLog /var/log/apache2/sling-cms-err.log
+   TransferLog /var/log/apache2/sling-cms-access.log
+   
+   ProxyPass /.well-known !
+   ProxyPass / http://localhost:8080/
+   ProxyPassReverse / http://localhost:8080/
+</VirtualHost>

--- a/docker/site.conf
+++ b/docker/site.conf
@@ -1,0 +1,58 @@
+#
+#		 Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#        agreements. See the NOTICE file distributed with this work for additional information
+#        regarding copyright ownership. The ASF licenses this file to you under the Apache License,
+#        Version 2.0 (the "License"); you may not use this file except in compliance with the
+#        License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#        Unless required by applicable law or agreed to in writing, software distributed under the
+#        License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+#        either express or implied. See the License for the specific language governing permissions
+#        and limitations under the License.
+#
+
+<VirtualHost *:80>
+   ServerName sling2.apache.org
+   DocumentRoot /var/www/vhosts/sling
+   ErrorLog /var/log/apache2/sling-err.log
+   TransferLog /var/log/apache2/sling-access.log
+   
+   # Configure mod_cache
+   CacheEnable disk /
+   CacheIgnoreNoLastMod On
+   CacheRoot /var/cache/httpd/danklco-com
+   CacheDefaultExpire 600
+   
+   # Configure mod_expire
+   ExpiresActive On
+   ExpiresDefault "access plus 1 month"
+   ExpiresByType text/html "access plus 5 minutes"
+   ExpiresByType application/json "access plus 5 minutes"
+   ExpiresByType image/gif "access plus 1 year"
+   ExpiresByType image/jpeg "access plus 1 year"
+   ExpiresByType image/png "access plus 1 year"
+   ExpiresByType text/css "access plus 1 month"
+   ExpiresByType text/javascript "access plus 1 month"
+   ExpiresByType application/javascript "access plus 1 month"
+   
+   # Configure Proxy
+   ProxyPass /.well-known !
+   ProxyPass /ERROR !
+   ProxyPass /static/clientlibs/reference/ http://localhost:8080/static/clientlibs/reference/ connectiontimeout=10 timeout=60 retry=0
+   ProxyPassReverse /static/clientlibs/reference/ http://localhost:8080/static/clientlibs/reference/
+   ProxyPass / http://localhost:8080/content/apache/sling-apache-org/ connectiontimeout=10 timeout=60 retry=0
+   ProxyPassReverse /content/apache/sling-apache-org/ http://localhost:8080/content/apache/sling-apache-org/ 
+   
+   # Security / Hardening
+   AllowEncodedSlashes on
+   RewriteRule "^.+\..*\.json" - [F,L]
+   RewriteCond %{REQUEST_METHOD} ^(delete|post|trace|track) [NC]
+   RewriteRule .* - [F,L]
+   Header set X-Frame-Options SAMEORIGIN
+   Header set X-XSS-Protection "1; mode=block"
+   Header set X-Content-Type-Options "nosniff"
+
+   
+   # Compress text files
+   AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
+   
+</VirtualHost>


### PR DESCRIPTION
Dockerfile was not runnable for several reasons:
1. the downloaded jar's name was wrong
2. Since rewrite module was not enabled RewriteRule configs were failing.
3. /var/log/httpd folder were in use for logs but it should be /var/log/apache2