### PR TITLE
Avoid interaction with tzdata

### DIFF
--- a/docker/webcache/Dockerfile
+++ b/docker/webcache/Dockerfile
@@ -15,6 +15,9 @@
 FROM ubuntu:latest
 MAINTAINER dev@sling.apache.org
 
+# Avoid interaction with tzdata
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Apache
 RUN apt-get update
 RUN apt-get install apache2 -y


### PR DESCRIPTION
Without this, tzdata asks me for timezone information while building the webcache images, and blocks instead of reading my response.