### PR TITLE
trivial - fixing cypress flakiness

### DIFF
--- a/it/cypress.config.js
+++ b/it/cypress.config.js
@@ -21,6 +21,11 @@ const { pa11y, prepareAudit } = require("@cypress-audit/pa11y");
 
 module.exports = defineConfig({
   e2e: {
+    reporter: 'junit',
+    reporterOptions: {
+      mochaFile: 'target/surefire-reports/TEST-[suiteName].xml',
+      toConsole: true,
+    },
     baseUrl: "http://localhost:8080",
     viewportWidth: 1000,
     viewportHeight: 660,

--- a/it/package.json
+++ b/it/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "tests/index.js",
   "scripts": {
-    "cypress:install": "./node_modules/.bin/cypress install",
+    "cypress:install": "./node_modules/.bin/cypress install --force",
     "cypress": "./node_modules/.bin/cypress open",
     "test": "./node_modules/.bin/cypress run",
     "wait-for-ready": "node cypress/ready.js"


### PR DESCRIPTION
Cypress builds have been failing due to missing dependencies:

```[STARTED] Task without title.
[FAILED] Cypress failed to start.
[FAILED] 
[FAILED] This may be due to a missing library or dependency. https://on.cypress.io/required-dependencies
[FAILED] 
[FAILED] Please refer to the error below for more details.
[FAILED] 
[FAILED] ----------
[FAILED] 
[FAILED] /home/jenkins/.cache/Cypress/12.17.4/Cypress/Cypress: error while loading shared libraries: libgbm.so.1: cannot open shared object file: No such file or directory
[FAILED] 
[FAILED] ----------
[FAILED] 
[FAILED] Platform: linux-x64 (Ubuntu - 22.04)
[FAILED] Cypress Version: 12.17.4
Cypress failed to start.

This may be due to a missing library or dependency. https://on.cypress.io/required-dependencies

Please refer to the error below for more details.

----------

/home/jenkins/.cache/Cypress/12.17.4/Cypress/Cypress: error while loading shared libraries: libgbm.so.1: cannot open shared object file: No such file or directory

----------

Platform: linux-x64 (Ubuntu - 22.04)```

Seeing a forcing install fixes the issue. 