### PR TITLE
trivial - adding jenkins build m2 repo to IT launcher config

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -110,6 +110,12 @@
                                             <org.osgi.service.http.port>${http.port}</org.osgi.service.http.port>
                                         </frameworkProperties>
                                     </launcherArguments>
+                                    <repositoryUrls>
+                                        <repositoryUrl>file:.repository</repositoryUrl>
+                                        <repositoryUrl>file:${user.home}/.m2/repository</repositoryUrl>
+                                        <repositoryUrl>https://repo.maven.apache.org/maven2</repositoryUrl>
+                                        <repositoryUrl>https://repository.apache.org/content/groups/snapshots</repositoryUrl>
+                                    </repositoryUrls>
                                     <startTimeoutSeconds>180</startTimeoutSeconds>
                                 </launch>
                             </launches>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -111,7 +111,7 @@
                                         </frameworkProperties>
                                     </launcherArguments>
                                     <repositoryUrls>
-                                        <repositoryUrl>file:.repository</repositoryUrl>
+                                        <repositoryUrl>file:${project.parent.basedir}/.repository</repositoryUrl>
                                         <repositoryUrl>file:${user.home}/.m2/repository</repositoryUrl>
                                         <repositoryUrl>https://repo.maven.apache.org/maven2</repositoryUrl>
                                         <repositoryUrl>https://repository.apache.org/content/groups/snapshots</repositoryUrl>


### PR DESCRIPTION
Build with new snapshot fails due to not being able to retrieve installed artifacts.